### PR TITLE
Fixed requirements for current Flask version

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, abort
-from flask_restplus import Api, Resource
+from flask_restx import Api, Resource
 from idasen import cli
 from subprocess import Popen, PIPE
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 idasen
 Flask
-flask_restplus
-werkzeug==0.16.1
+flask_restx
+werkzeug


### PR DESCRIPTION
Flask Restplus is deprecated and has a drop-in replacement called restx. I updated the requirements and fixed the import in the script to make it usable with current versions